### PR TITLE
Add support for Bitbucket pipelines

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,0 +1,30 @@
+definitions:
+  steps:
+    - step: &generate_sdks_and_pull_request
+        name: Generate SDKs and Pull Request
+        image: node:20
+        caches:
+          - node
+        script:
+          - |
+            # Check for changes in the specified files or directories
+            if git diff --quiet HEAD~1 -- liblab.config.json spec/ hooks/ customPlanModifiers/; then
+              echo "No changes detected in relevant files. Skipping step."
+              exit 0
+            fi
+          - |
+            if [ -z "$LIBLAB_TOKEN" ] || [ -z "$LIBLAB_BITBUCKET_TOKEN" ]; then
+              echo "Error: Variables LIBLAB_TOKEN and LIBLAB_BITBUCKET_TOKEN are required, see https://developers.liblab.com/tutorials/integrate-with-BITBUCKET-actions/#create-tokens"
+              exit 1
+            fi
+          - npm install -g liblab
+          - liblab build --yes --pr -p bitbucket
+
+pipelines:
+  branches:
+    main:
+      - step: *generate_sdks_and_pull_request
+
+  pull-requests:
+    '**':
+      - step: *generate_sdks_and_pull_request


### PR DESCRIPTION
Added support for running the CI/CD pipelines on bitbucket.

This pipeline runs on each pull-request and each time the main branch gets new changes.

It will check for changes on any of these files/folders:
- `liblab.config.json`
- `spec/`
- `hooks/`
- `customPlanModifiers/`

Requires these variables to be defined:
- `LIBLAB_TOKEN`
- `LIBLAB_GITHUB_TOKEN`

Installs the liblab package and builds the app using liblab with the `bitbucket` platform flag